### PR TITLE
Initial resonate support

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -82,6 +82,7 @@ wifi:
     - script.execute: control_leds
   on_disconnect:
     - script.execute: control_leds
+  power_save_mode: NONE  # Needed to maintain good Resonate sync
 
 network:
   enable_ipv6: true
@@ -221,12 +222,18 @@ switch:
       - if:
           condition:
             media_player.is_announcing:
+              id: external_media_player
           then:
             media_player.stop:
               announcement: true
+              id: external_media_player
       # Set back ducking ratio to zero
       - mixer_speaker.apply_ducking:
           id: media_mixing_input
+          decibel_reduction: 0
+          duration: 1.0s
+      - mixer_speaker.apply_ducking:
+          id: resonate_mixing_input
           decibel_reduction: 0
           duration: 1.0s
       # Refresh the LED ring
@@ -235,6 +242,10 @@ switch:
       # Duck audio
       - mixer_speaker.apply_ducking:
           id: media_mixing_input
+          decibel_reduction: 20
+          duration: 0.0s
+      - mixer_speaker.apply_ducking:
+          id: resonate_mixing_input
           decibel_reduction: 20
           duration: 0.0s
       # Enable stop wake word
@@ -302,22 +313,25 @@ binary_sensor:
                             - if:
                                 condition:
                                   media_player.is_announcing:
+                                    id: external_media_player
                                 then:
                                   media_player.stop:
                                     announcement: true
+                                    id: external_media_player
                                 else:
                                   - if:
                                       condition:
                                         media_player.is_playing:
+                                          id: external_media_player
                                       then:
                                         - media_player.pause:
+                                            id: external_media_player
                                       else:
                                         - if:
                                             condition:
                                               and:
                                                 - switch.is_off: master_mute_switch
-                                                - not:
-                                                    voice_assistant.is_running
+                                                - not: voice_assistant.is_running
                                             then:
                                               - script.execute:
                                                   id: play_sound
@@ -1246,8 +1260,10 @@ script:
             lambda: return increase_volume;
           then:
             - media_player.volume_up:
+                id: external_media_player
           else:
             - media_player.volume_down:
+                id: external_media_player
       - script.execute: control_leds
       - delay: 1s
       - lambda: id(dial_touched) = false;
@@ -1411,6 +1427,7 @@ script:
             - wait_until:
                 not:
                   media_player.is_announcing:
+                    id: external_media_player
             - if:
                 condition:
                   switch.is_off: timer_ringing
@@ -1464,11 +1481,15 @@ speaker:
     id: mixing_speaker
     output_speaker: i2s_audio_speaker
     num_channels: 2
+    task_stack_in_psram: true
     source_speakers:
       - id: announcement_mixing_input
         timeout: never
       - id: media_mixing_input
         timeout: never
+      - id: resonate_mixing_input
+        timeout: never
+        buffer_duration: 200ms
 
   # Vritual speakers to resample each pipelines' audio, if necessary, as the mixer speaker requires the same sample rate
   - platform: resampler
@@ -1481,12 +1502,38 @@ speaker:
     output_speaker: media_mixing_input
     sample_rate: 48000
     bits_per_sample: 16
+  - platform: resampler
+    id: resonate_resampling_speaker
+    output_speaker: resonate_mixing_input
+    # output_speaker: i2s_audio_speaker
+    task_stack_in_psram: true
+    sample_rate: 48000
+    bits_per_sample: 16
+
+resonate:
+  id: resonate_hub
+  task_stack_in_psram: true
+  kalman_process_error: 0.01
 
 media_player:
+  - platform: resonate
+    id: resonate_media_player
+    name: Resonate Media Player
+    speaker: resonate_resampling_speaker
+    task_stack_in_psram: true
+    volume_min: 0.4
+    volume_max: 0.85
+    on_state:
+      - lambda: |-
+          if (id(external_media_player).is_ready()) {
+            id(external_media_player).volume = id(resonate_media_player).volume;
+            id(external_media_player)->publish_state();
+          }
   - platform: speaker
     id: external_media_player
     name: Media Player
     internal: False
+    task_stack_in_psram: true
     volume_increment: 0.05
     volume_min: 0.4
     volume_max: 0.85
@@ -1506,9 +1553,17 @@ media_player:
       - script.execute: control_leds
     on_volume:
       - script.execute: control_leds
+      - lambda: |-
+          if (id(resonate_media_player).is_ready()) {
+            id(resonate_media_player)->sync_speaker_volume();
+          }
     on_announcement:
       - mixer_speaker.apply_ducking:
           id: media_mixing_input
+          decibel_reduction: 20
+          duration: 0.0s
+      - mixer_speaker.apply_ducking:
+          id: resonate_mixing_input
           decibel_reduction: 20
           duration: 0.0s
     on_state:
@@ -1519,10 +1574,14 @@ media_player:
             - not:
                 voice_assistant.is_running:
             - not:
-                media_player.is_announcing:
+                media_player.is_announcing: external_media_player
         then:
           - mixer_speaker.apply_ducking:
               id: media_mixing_input
+              decibel_reduction: 0
+              duration: 1.0s
+          - mixer_speaker.apply_ducking:
+              id: resonate_mixing_input
               decibel_reduction: 0
               duration: 1.0s
     files:
@@ -1576,6 +1635,12 @@ external_components:
     components:
       - voice_kit
     refresh: 0s
+  - source:
+      type: git
+      url: https://github.com/esphome/esphome
+      ref: 2149c3c0baed68259ea3fb7fb425e606db785e5b
+    components: [audio, mdns, mixer, resampler, resonate]
+    refresh: 0s
 
 audio_dac:
   - platform: aic3204
@@ -1624,9 +1689,11 @@ micro_wake_word:
                       - if:
                           condition:
                             media_player.is_announcing:
+                              id: external_media_player
                           then:
                             - media_player.stop:
                                 announcement: true
+                                id: external_media_player
                           # Start the voice assistant and play the wake sound, if enabled
                           else:
                             - if:
@@ -1717,8 +1784,12 @@ voice_assistant:
   on_start:
     - mixer_speaker.apply_ducking:
         id: media_mixing_input
-        decibel_reduction: 20  # Number of dB quieter; higher implies more quiet, 0 implies full volume
-        duration: 0.0s         # The duration of the transition (default is no transition)
+        decibel_reduction: 20 # Number of dB quieter; higher implies more quiet, 0 implies full volume
+        duration: 0.0s # The duration of the transition (default is no transition)
+    - mixer_speaker.apply_ducking:
+        id: resonate_mixing_input
+        decibel_reduction: 20
+        duration: 0.0s
   on_listening:
     - lambda: id(voice_assistant_phase) = ${voice_assist_waiting_for_command_phase_id};
     - script.execute: control_leds
@@ -1756,6 +1827,10 @@ voice_assistant:
     # Stop ducking audio.
     - mixer_speaker.apply_ducking:
         id: media_mixing_input
+        decibel_reduction: 0
+        duration: 1.0s
+    - mixer_speaker.apply_ducking:
+        id: resonate_mixing_input
         decibel_reduction: 0
         duration: 1.0s
     # If the end happened because of an error, let the error phase on for a second

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1784,8 +1784,8 @@ voice_assistant:
   on_start:
     - mixer_speaker.apply_ducking:
         id: media_mixing_input
-        decibel_reduction: 20 # Number of dB quieter; higher implies more quiet, 0 implies full volume
-        duration: 0.0s # The duration of the transition (default is no transition)
+        decibel_reduction: 20  # Number of dB quieter; higher implies more quiet, 0 implies full volume
+        duration: 0.0s  # The duration of the transition (default is no transition)
     - mixer_speaker.apply_ducking:
         id: resonate_mixing_input
         decibel_reduction: 20


### PR DESCRIPTION
Adds a new Resonate media player that handles streaming audio from a Resonate server. 
- Audio ducking is applied to this media players output just like the regular media player's
- Volume between the two players are kept in sync

Limitations:
- Trying to start a file on the Resonate media player does nothing
- The center button does not control the Resonate media player in any way
- There is no lock preventing both the regular media player and Resonate media player to play music at the same time, so in theory, you could have three different audio streams (announcements) all playing at once

Known Issues:
- If the player falls behind too much it can never catch up (this is fairly rare!). Pause the stream and resume if this happens
- It logs sync messages excessively for debugging purposes