### PR TITLE
Attempt to fix wrong URL to the manifest

### DIFF
--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -33,4 +33,4 @@ jobs:
           r2-secret-access-key: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
           r2-bucket: ${{ secrets.CLOUDFLARE_R2_BUCKET }}
           source-dir: output
-          destination-dir: home-assistant-voice-pe/${{ matrix.device }}/
+          destination-dir: home-assistant-voice-pe-alpha/${{ matrix.device }}/


### PR DESCRIPTION
When trying to perform on OTA on the device, it looks for the firmware manifest in the home-assistant-voice-pe-alpha directory.