### PR TITLE
Build with IDF 5.5.1 and use updated resonate code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       files: |
         home-assistant-voice.factory.yaml
-      esphome-version: 2025.9.3
+      esphome-version: 2025.10.3
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       files: |
         home-assistant-voice.factory.yaml
-      esphome-version: 2025.10.3
+      esphome-version: dev
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -32,7 +32,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2025.9.3
+  min_version: 2025.10.3
   on_boot:
     priority: 375
     then:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -32,7 +32,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2025.10.3
+  min_version: 2025.11.0
   on_boot:
     priority: 375
     then:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -56,7 +56,7 @@ esp32:
   flash_size: 16MB
   framework:
     type: esp-idf
-    version: recommended
+    version: 5.5.1
     sdkconfig_options:
       CONFIG_ESP32S3_DATA_CACHE_64KB: "y"
       CONFIG_ESP32S3_DATA_CACHE_LINE_64B: "y"
@@ -1638,8 +1638,8 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome/esphome
-      ref: 7ba12768dc05000ed2e4094381af891f8b58786f
-    components: [audio, mdns, mixer, resampler, resonate]
+      ref: ef1775727fb6d37c9911828776349ce685a416c4
+    components: [audio, mdns, mixer, psram, resampler, resonate, speaker]
     refresh: 0s
 
 audio_dac:


### PR DESCRIPTION
This PR builds with esp-idf 5.5.1 which includes a critical bugfix for the esp http websocket server that would cause new versions of aioresonate to fail consistently.

Bumps the resonate commit reference for these changes:
 - Improvement: use better WiFi driver settings for better throughput
 - Improvement: better handling when sync falls way behind
 - Bugfix: stream more consistently restarts when moving onto the next track
 - Bugfix: send a time messages only after sending hello message
 - Bugfix: avoid duplicate decoder task start attempts
 - Bugfix: properly reset state after a server disconnects
