### PR TITLE
Bugfix: Fix mixing

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1638,7 +1638,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome/esphome
-      ref: ef1775727fb6d37c9911828776349ce685a416c4
+      ref: f743f0add8da4b66634854d864395404718171ba
     components: [audio, mdns, mixer, psram, resampler, resonate, speaker]
     refresh: 0s
 


### PR DESCRIPTION
Resonate currently fails when it needs to mix audio; e.g., you use the voice assistant. It was caused by a rebasing mistake that accidentally delete a line from the mixer speaker source code. This PR bumps the referenced commit to one that fixes it.