### PR TITLE
Use builtin ESPHome network optimization and build with 2025.11.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     with:
       files: |
         home-assistant-voice.factory.yaml
-      esphome-version: dev
+      esphome-version: 2025.11.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1639,7 +1639,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome/esphome
-      ref: 3f28ae0eaaba84c0225bad090b77a2acef3b90b0
+      ref: 3ecdf16d7555a80baa712273a1ca5c5134e6cf04
     components: [audio, mdns, mixer, resampler, resonate]
     refresh: 0s
 

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -113,6 +113,7 @@ i2c:
 psram:
   mode: octal
   speed: 80MHz
+  ignore_not_found: false
 
 globals:
   # Global index for our LEDs. So that switching between different animation does not lead to unwanted effects.
@@ -1638,8 +1639,8 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome/esphome
-      ref: f743f0add8da4b66634854d864395404718171ba
-    components: [audio, mdns, mixer, psram, resampler, resonate, speaker]
+      ref: 3f28ae0eaaba84c0225bad090b77a2acef3b90b0
+    components: [audio, mdns, mixer, resampler, resonate]
     refresh: 0s
 
 audio_dac:


### PR DESCRIPTION
- Builds with ESPHome 2025.11.0
- Uses ESPHome's built in mechanism for optimizing the networking stack. We no longer need the snapshot branches psram and speaker components.
- Fixes the resonate media player getting in a stuck state with rapid stopping and starting