### PR TITLE
Change update manifest source to point to the beta channel

### DIFF
--- a/home-assistant-voice.factory.yaml
+++ b/home-assistant-voice.factory.yaml
@@ -28,10 +28,10 @@ update:
   - platform: http_request
     name: None
     id: update_http_request
-    source: https://firmware.esphome.io/home-assistant-voice-pe-alpha/home-assistant-voice/manifest-alpha.json
+    source: https://firmware.esphome.io/home-assistant-voice-pe/home-assistant-voice/manifest-beta.json
 
 dashboard_import:
-  package_import_url: github://esphome/home-assistant-voice-pe-alpha/home-assistant-voice.yaml
+  package_import_url: github://esphome/home-assistant-voice-pe/home-assistant-voice.yaml
 
 wifi:
   on_connect:


### PR DESCRIPTION
This PR will cause future updates to pull from the main repo's beta branch. This will get users still on the alpha channel back to the regular beta/stable firmware channel. The current beta/stable channels include Sendspin and many additional fixes since the last alpha firmware was released.